### PR TITLE
Suppress `EventEmitter memory leak detected` message

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,9 @@
 var fs = require("fs")
   , path = require("path")
   , concatStream = require("concat-stream")
-  , CombineStream = require("combine-stream")
+  , seriesStream = require("series-stream")
   , async = require("async")
   , stream = require("stream")
-  , Buffer = require("buffer").Buffer
   , mkdirp = require("mkdirp")
 
 function createFrom (createStream) {
@@ -48,9 +47,11 @@ function createFrom (createStream) {
   exports.concat.from = function concatFromPath (paths, opts) {
     paths = Array.isArray(paths) ? paths : [paths]
 
-    var srcStream = new CombineStream(paths.map(function (p) {
-      return fs.createReadStream(p, opts)
-    }))
+    var srcStream = seriesStream()
+
+    paths.forEach(function (p) {
+      srcStream.add(fs.createReadStream(p, opts))
+    })
 
     return createTo([paths], [srcStream], createStream, false)
   }

--- a/index.js
+++ b/index.js
@@ -48,6 +48,7 @@ function createFrom (createStream) {
     paths = Array.isArray(paths) ? paths : [paths]
 
     var srcStream = seriesStream()
+    srcStream.setMaxListeners(paths.length)
 
     paths.forEach(function (p) {
       srcStream.add(fs.createReadStream(p, opts))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stream-from-to",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Utility for piping to/from a stream from a variety of sources to a variety of destinations",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -15,12 +15,12 @@
   "homepage": "https://github.com/alanshaw/stream-from-to",
   "dependencies": {
     "async": "^0.9.0",
-    "combine-stream": "0.0.4",
+    "series-stream": "^1.0.1",
     "concat-stream": "^1.4.7",
     "mkdirp": "^0.5.0"
   },
   "devDependencies": {
-    "rimraf": "~2.2.5",
+    "rimraf": "^2.3.1",
     "tape": "^3.4.0",
     "through": "~2.3.4"
   }


### PR DESCRIPTION
When concatenating more than 10 files we get the following message 

> (node) warning: possible EventEmitter memory leak detected. 11 unpipe listeners added. Use emitter.setMaxListeners() to increase limit.

This PR changes the listeners limit to equal the number of files we are concatenating.

**Note** the reason this PR has some commits from you is because the changes were made on top of  tag `v1.4.2` so the change is on [L51](https://github.com/alanshaw/stream-from-to/pull/2/files#diff-168726dbe96b3ce427e7fedce31bb0bcR51)